### PR TITLE
Более подробный отчёт об ошибке

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,36 @@
-var map = require('map-stream');
-var beml = require('beml');
+const path = require('path');
+const map = require('map-stream');
+const beml = require('beml');
+const gutil = require('gulp-util');
+const through = require('through2');
 
-module.exports = function(config) {
+module.exports = (opts) => {
 
-  function bemlStream(file, callback) {
-    if (!file.isNull()) {
-      var html = beml(file.contents, config);
-      file.contents = new Buffer(html);
-      callback(null, file);
-    }
-  }
+    return through.obj(function (file, enc, cb) {
+        if (file.isNull()) {
+            cb(null, file);
+            return;
+        }
 
-  return map(bemlStream);
+        if (file.isStream()) {
+            cb(new gutil.PluginError('gulp-beml', 'Streaming not supported'));
+            return;
+        }
 
+        try {
+            file.contents = new Buffer(beml(file.contents.toString(), opts));
+            this.push(file);
+        } catch (err) {
+
+            Object.assign(err, {
+                filePath: file.path,
+                fileName: path.basename(file.path),
+                message: `${err.message} in (${path.basename(file.path)})`
+            });
+
+            this.emit('error', new gutil.PluginError('gulp-beml', err));
+        }
+
+        cb();
+    });
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "beml": "^1.0.0",
-    "map-stream": "^0.1.0"
+    "map-stream": "^0.1.0",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "gulp-util": "^2.2.14",


### PR DESCRIPTION
Без этого изменения было сложно понять в каком файле произошла ошибка, плагин просто сообщал что произошла ошибка, сделать внятное решение своими силами (понять в каком файле что-то сломалось), не вышло.
Писал по инструкции [gulp-plugin-boilerplate](https://github.com/sindresorhus/gulp-plugin-boilerplate)
